### PR TITLE
Use default value if none is provided

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -98,11 +98,11 @@ const load = () => {
   fields.forEach((field) => {
     let hashValue = hashFields[field.key];
     if (hashValue) hashValue = JSON.parse(decodeURI(hashValue));
-    // Prefer query param but fall back to local storage
+    // Prefer query param but fall back to local storage or default value
     field.value =
       hashValue !== undefined
         ? hashValue
-        : JSON.parse(localStorage.getItem(field.key));
+        : JSON.parse(localStorage.getItem(field.key)) || field.value;
     field.element.value = field.value;
     field.element.checked = field.value;
   });


### PR DESCRIPTION
There was an error where we added a default value for horizon, but some people might have cached a null version of it.  This allows us to use the default value even if something bad is saved